### PR TITLE
* use fork to spawn node process instead of spawn

### DIFF
--- a/repository.js
+++ b/repository.js
@@ -72,7 +72,7 @@ var startMonitor = function(callback) {
 		});
 	};
 	var fork = function() {
-		var child = proc.spawn('node', [__dirname+'/monitor.js'], {
+		var child = proc.fork('monitor.js', {
 			detached:true,
 			stdio:['ignore','ignore','ignore']
 		});


### PR DESCRIPTION
- works on systems that don't call the node executable "node"
- works if node is not on the path
