### PR TITLE
Add option to disable the monitor

### DIFF
--- a/repository.js
+++ b/repository.js
@@ -115,7 +115,9 @@ var listen = function(options) {
 		});
 	};
 
-	startMonitor(onmonitor.put);
+	if (options.useMonitor) {
+		startMonitor(onmonitor.put);
+	}
 
 	var cache = {};
 	var own = new Repository(id);


### PR DESCRIPTION
This does not work with node-webkit since the fork will break
given how node-webkit implemented child_process.fork()

I did not add something to the Readme.md as I actually don't really know what the monitor is for ;-)
Does not seem to do any harm to run without it.
