### PR TITLE
Heartbeat is now configurable

### DIFF
--- a/repository.js
+++ b/repository.js
@@ -161,7 +161,7 @@ var listen = function(options) {
 		});
 
 		clearTimeout(heartbeat);
-		heartbeat = setTimeout(gc, HEARTBEAT);
+		heartbeat = setTimeout(gc, options.heartbeat || HEARTBEAT);
 	};
 	var onresponse = function(repo) {
 		return function(err, res, body) {


### PR DESCRIPTION
Lets you send in a optional param for heartbeat timeout, otherwise defaults to the current 2min timeout.
