### PR TITLE
Fix remote push being added to receiving local repo

### DIFF
--- a/repository.js
+++ b/repository.js
@@ -189,7 +189,7 @@ var listen = function(options) {
 			request.post({
 				uri: repo.uri + '/data/' + key,
 				headers: {
-					'x-repository': repo.uri
+					'x-repository': own.uri
 				},
 				json: true,
 				body: values


### PR DESCRIPTION
When a remote node pushes updated services, it sets the x-repository
header to identify the repo name. The remote node was setting the
remote repo uri instead of setting the local uri. This caused the
receiving node to add the service to its own local repo.
